### PR TITLE
Changed url to dipsasa.github.io

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -13,7 +13,7 @@ description: > # this means to ignore newlines until "baseurl:"
   line in _config.yml. It will appear in your document head meta (for
   Google search results) and in your feed.xml site description.
 baseurl: "" # the subpath of your site, e.g. /blog
-url: "http://localhost:4000/" # the base hostname & protocol for your site
+url: "http://dipsasa.github.io" # the base hostname & protocol for your site
 twitter_username: DIPSASA
 github_username: DIPSASA
 facebook_username: DIPS-ASA-100422586702214/?fref=ts


### PR DESCRIPTION
We need to change this to http://tech.dips.no when the new domain is up