### PR TITLE
Added fix for post images hosted in repo

### DIFF
--- a/feed.xml
+++ b/feed.xml
@@ -15,12 +15,18 @@ layout: null
       <item>
         <title>{{ post.title | xml_escape }}</title>
         {% if post.excerpt %}
-					<description>{{ post.excerpt | xml_escape }}</description>
-				{% else %}
-					<description>{{ post.content | xml_escape }}</description>
-				{% endif %}
+		<description>{{ post.excerpt | xml_escape }}</description>
+	{% else %}
+		<description>{{ post.content | xml_escape }}</description>
+	{% endif %}
         {% if post.img %}
-        <image>{{ post.img }}</image>
+        <image>
+        {% if post.img contains 'http://' %}
+		{{ post.img }}
+	{% else %}
+		{{ post.img | prepend: site.url }}
+	{% endif %}
+       	</image>
         {% endif %}
         <pubDate>{{ post.date | date_to_rfc822 }}</pubDate>
         <link>{{ post.url | prepend: site.baseurl | prepend: site.url }}</link>


### PR DESCRIPTION
If a post image is hosted on github the post.img url will be "img/myimage.png" to fix this we prepend the site url.